### PR TITLE
Fix "java.lang.IllegalStateException: Nesting problem." on Exceptions

### DIFF
--- a/app/src/main/java/org/fitchfamily/android/wifi_backend/data/ExportSpiceRequest.java
+++ b/app/src/main/java/org/fitchfamily/android/wifi_backend/data/ExportSpiceRequest.java
@@ -73,9 +73,9 @@ public class ExportSpiceRequest extends SpiceRequest<ExportSpiceRequest.Result> 
                         AccessPointAdapter.instance.write(writer, accessPoint);
                     } while (cursor.moveToNext());
                 }
-            } finally {
-                writer.endArray().flush();
 
+                writer.endArray().flush();
+            } finally {
                 if (cursor != null) {
                     cursor.close();
                 }


### PR DESCRIPTION
This removes calling writer.endArray() from the finally clause to make the real exception "visible".

This helps solving <https://github.com/n76/wifi_backend/pull/19#issuecomment-172299503>.
