### PR TITLE
Ignore null AccessPoint

### DIFF
--- a/app/src/main/java/org/fitchfamily/android/wifi_backend/data/ExportSpiceRequest.java
+++ b/app/src/main/java/org/fitchfamily/android/wifi_backend/data/ExportSpiceRequest.java
@@ -70,7 +70,10 @@ public class ExportSpiceRequest extends SpiceRequest<ExportSpiceRequest.Result> 
                 if (cursor != null && cursor.moveToFirst()) {
                     do {
                         AccessPoint accessPoint = SamplerDatabase.getInstance(context).query(cursor.getString(0));
-                        AccessPointAdapter.instance.write(writer, accessPoint);
+
+                        if(accessPoint != null) {
+                            AccessPointAdapter.instance.write(writer, accessPoint);
+                        }
                     } while (cursor.moveToNext());
                 }
 


### PR DESCRIPTION
In some rare cases (database from old version?) the bssid at the database is not normalized with AccessPoint.bssid() and querying for such an bssid will return null (because Database.query() internally normalizes it on querying).

This fixes the issue mentioned at <https://github.com/n76/wifi_backend/pull/21#issuecomment-172300552>.