### PR TITLE
Add Huawei to blacklist

### DIFF
--- a/app/src/main/java/org/fitchfamily/android/wifi_backend/wifi/WifiBlacklist.java
+++ b/app/src/main/java/org/fitchfamily/android/wifi_backend/wifi/WifiBlacklist.java
@@ -35,6 +35,7 @@ public abstract class WifiBlacklist {
                 SSID.startsWith("CellSpot") ||             // T-Mobile US portable cell based WiFi
                 SSID.startsWith("CoachAmerica") ||         // Charter bus service with on board WiFi
                 SSID.startsWith("DisneyLandResortExpress") ||              // Bus with on board WiFi
+                SSID.startsWith("HUAWEI-") ||
                 SSID.startsWith("Samsung Galaxy") ||       // mobile AP
                 SSID.startsWith("TaxiLinQ") ||             // Mobile AP, see http://www.mobile-knowledge.com/products/driver-solutions/taxilinq/
 


### PR DESCRIPTION
I've observed several instances of such SSIDs while capturing data with various apps.

In my experience, they're always mobile phones.